### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/diem-core.yml
+++ b/.github/workflows/diem-core.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        run: echo "::set-output name=current-version::$(cat ${1-.}/package.json | jq '.version' | tr -d '"')"
+        run: echo "current-version=$(cat ${1-.}/package.json | jq '.version' | tr -d '"')" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/diem-default.yml
+++ b/.github/workflows/diem-default.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get branch name
         id: branch-name
-        run: echo "::set-output name=branch::${GITHUB_REF/refs\/heads\//}"
+        run: echo "branch=${GITHUB_REF/refs\/heads\//}" >> "$GITHUB_OUTPUT"
       - name: "Send Message to Slack"
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get branch name
         id: branch-name
-        run: echo "::set-output name=branch::${GITHUB_REF/refs\/heads\//}"
+        run: echo "branch=${GITHUB_REF/refs\/heads\//}" >> "$GITHUB_OUTPUT"
       - name: "Send Message to Slack"
         id: slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/diem-help.yml
+++ b/.github/workflows/diem-help.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        run: echo "::set-output name=current-version::$(cat ${1-.}/package.json | jq '.version' | tr -d '"')"
+        run: echo "current-version=$(cat ${1-.}/package.json | jq '.version' | tr -d '"')" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/diem-nodepy.yml
+++ b/.github/workflows/diem-nodepy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        run: echo "::set-output name=current-version::$(cat ${1-.}/package.json | jq '.version' | tr -d '"')"
+        run: echo "current-version=$(cat ${1-.}/package.json | jq '.version' | tr -d '"')" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/diem-operator.yml
+++ b/.github/workflows/diem-operator.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        run: echo "::set-output name=current-version::$(cat ${1-.}/package.json | jq '.version' | tr -d '"')"
+        run: echo "current-version=$(cat ${1-.}/package.json | jq '.version' | tr -d '"')" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/diem-slack-bot.yml
+++ b/.github/workflows/diem-slack-bot.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        run: echo "::set-output name=current-version::$(cat ${1-.}/package.json | jq '.version' | tr -d '"')"
+        run: echo "current-version=$(cat ${1-.}/package.json | jq '.version' | tr -d '"')" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/mongoloader.yml
+++ b/.github/workflows/mongoloader.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        run: echo "::set-output name=current-version::$(cat ${1-.}/package.json | jq '.version' | tr -d '"')"
+        run: echo "current-version=$(cat ${1-.}/package.json | jq '.version' | tr -d '"')" >> "$GITHUB_OUTPUT"
 
       - name: Use Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter